### PR TITLE
Tarugo22 map

### DIFF
--- a/_includes/partials/location.njk
+++ b/_includes/partials/location.njk
@@ -12,7 +12,7 @@
   </div>
 
   <div class="location-map">
-      <iframe width="750" height="510" frameborder="0" title="Felt Map" src="https://felt.com/embed/map/Software-confs-68eR49ClbSRSaGwc1hBxXzD?lat=40.34672620384461&lon=-3.6952176143847777&zoom=16.969"></iframe>
+      <iframe width="750" height="510" frameborder="0" title="Felt Map" src="https://felt.com/embed/map/TarugoConf-22-GvehZWwSRwWTfE313rL9BaD?lat=40.34672620384461&lon=-3.6972176143847777&zoom=16.969"></iframe>
   </div>
 
 </section>


### PR DESCRIPTION
Cambio del mapa comunitario a uno específico para la Tarugo, tras [una conversación con @dbonillaf](https://twitter.com/david_bonilla/status/1544925658169905152). Enlace al mapa: https://felt.com/map/TarugoConf-22-GvehZWwSRwWTfE313rL9BaD?lat=40.34712237091136&lon=-3.69372644262145&zoom=17.5