### PR TITLE
Open space and Saturday activities have 2 different pages

### DIFF
--- a/_includes/layouts/open-space.njk
+++ b/_includes/layouts/open-space.njk
@@ -1,0 +1,25 @@
+---
+layout: layouts/base.njk
+---
+{% include "partials/navbar.njk" %}
+
+<header class="header">
+  <h1 class="header-title">{{ header.title }}</h1>
+  <div class="header-intro">
+      {{ header.intro | md | safe }}
+  </div>
+</header>
+
+<figure class="video is-sabado">
+  <tarugo-video id="video" class="video-ratio" data-id="746603787">
+    <img src="/img/open-space-snapshot.jpg" alt="Open Space Tarugo">
+    <a href="https://vimeo.com/746603787">#tarugoff</a>
+  </tarugo-video>
+</figure>
+
+<div class="text">
+  {{ participating.description | md | safe }}
+</div>
+
+{% set content = faq %}
+{% include "partials/faq.njk" %}

--- a/_includes/layouts/sabado-tarugo.njk
+++ b/_includes/layouts/sabado-tarugo.njk
@@ -10,13 +10,6 @@ layout: layouts/base.njk
   </div>
 </header>
 
-<figure class="video is-sabado">
-  <tarugo-video id="video" class="video-ratio" data-id="746603787">
-    <img src="/img/open-space-snapshot.jpg" alt="Open Space Tarugo">
-    <a href="https://vimeo.com/746603787">#tarugoff</a>
-  </tarugo-video>
-</figure>
-
 <tarugo-filter class="activities" id="activities">
   <form class="activities-filter">
     <div class="activities-tags">
@@ -29,7 +22,7 @@ layout: layouts/base.njk
     </div>
   </form>
 
-  <ul class="activities-items">  
+  <ul class="activities-items">
     {% for item in activities.items %}
     <li class="activity item" data-tags="{{ item.tags | dump }}">
       <img src="{{ item.img }}" alt="" class="activity-image">
@@ -48,18 +41,6 @@ layout: layouts/base.njk
     {% endfor %}
   </ul>
 </tarugo-filter>
-
-<!--
-<section class="header">
-  <h2 class="header-title">{{ sessions.title }}</h2>
-  <div class="header-intro">
-      {{ sessions.text | md | safe }}
-  </div>
-  <div class="header-cta">
-    <a href="{{ sessions.cta.url }}" class="button is-primary">{{ sessions.cta.text }}</a>
-  </div>
-</section>
--->
 
 {% set content = faq %}
 {% include "partials/faq.njk" %}

--- a/open-space.yml
+++ b/open-space.yml
@@ -1,0 +1,69 @@
+layout: layouts/open-space.njk
+metas:
+  title: Sábado Tarugo
+  description: "La jornada más festiva de la #tarugo22"
+  image: ""
+title: Tarugoff
+description: > 
+  La Tarugoff es el Open Space de la Tarugoconf y nació como un
+  espacio para que los asistentes pudiesen hablar y debatir de 
+  sus propios intereses.
+menu: null
+cta:
+  text: Enviar sesión
+  url: https://forms.gle/L6AH6R3YwjgvHuWW6
+back:
+  text: ← Home
+  href: /
+header:
+  title: Tarugoff
+  intro: >
+    La Tarugoff es el Open Space de la Tarugoconf y nació como un
+    espacio para que los asistentes pudiesen hablar y debatir de 
+    sus propios intereses. 
+    
+    
+    El formato es muy conocido por muchos de los asistentes, pero si no
+    sabes lo que es un Open Space, <a href="https://www.agilealliance.org/glossary/open-space/" target="_blank">
+    aquí tienes una web</a> que lo explica muy
+    bien. Además siempre puedes ver el vídeo de Yeray, que será la persona
+    encargada de organizar y facilitar este espacio dentro del 
+    <a href="/sabado-tarugo">Sábado Tarugo</a>
+participating:
+  description: >
+    Para participar puedes hacer click en el botón de la barra superior con
+    la etiqueta "Enviar sesión", o si lo prefieres puede hacer 
+    <a href="https://forms.gle/L6AH6R3YwjgvHuWW6" target="_blank">click aquí</a> :-)
+  
+    
+    Proponer una sesión es realmente sencillo, sólo tienes que grabar un vídeo
+    y enviarlo, luego nosotros colgaremos todos los vídeos para que los asistentes
+    sepan de qué temas se quiere hablar.
+    
+    ¿Y si no se me ocurre nada ahora? No te preocupes, el sábado dejaremos tiempo para 
+    que la gente proponga otros temas antes de pasar a la votación de sesiones. **Pero 
+    recuerda que si proponemos las charlas con antelación el proceso será más fluido**.
+faq:
+  title: FAQ
+  questions:
+    - question: Mi sesión no ha salido elegida en la TarugOff, ¿y ahora qué hago?
+      answer: >
+        Pues no pasa nada, disfruta de las sesiones que han salido, o si te
+        encuentras por los pasillos con personas a las 
+
+        que les interesaba tu propuesta, id a tomar un café y hablad sobre ello. Recuerda que la única regla es la regla de 
+
+        los 2 pies ;-)
+    - question: ¿De qué temas se pueden hablar en la TarugoOff?
+      answer: >
+        En honor al espíritu abierto de un Open Space, se puede proponer
+        cualquier tema. Pero en un evento basado en 
+
+        desarrollo de producto, es posible que no haya gente experta en el cultivo de la vid, por lo que es más productivo limitarse a la temática propuesta. Desarrollo de producto es una temática bastante amplia que abarca desde aspectos técnicos a logísticos, pasando por marketing, financiación, diseño y un largo etcétera.
+    - question: ¿Puedo proponer más de una sesión en la TarugOff?
+      answer: |
+        Sí, puedes presentar tantas como quieras.
+    - question: ¡Tengo más dudas!
+      answer: No pasa nada. Como siempre, escribe a
+        [tarugoconf@bonillaware.com](mailto:tarugoconf@bonillaware.com) y allí
+        estaremos encantados de atenderte.

--- a/sabado-tarugo.yml
+++ b/sabado-tarugo.yml
@@ -11,9 +11,6 @@ description: Después de las emociones fuertes del viernes, el Sábado Tarugo es
   pasar un buen rato con todas las actividades que hemos preparado que
   disfrutarán por igual, mayores y pequeños.
 menu: null
-cta:
-  text: Enviar sesión
-  url: https://forms.gle/L6AH6R3YwjgvHuWW6
 back:
   text: ← Home
   href: /
@@ -21,8 +18,8 @@ header:
   title: 🎉 Sábado Tarugo
   intro: Después de las emociones fuertes del viernes, el Sábado Tarugo es **una
     jornada diseñada para que los asistentes puedan disfrutar relajadamente sin
-    una agenda marcada**. No solo podrán participar en la TarugOff  —nuestro
-    Open Space— sino también traer a familia, amigos y compañeros de trabajo
+    una agenda marcada**. No solo podrán participar en la <a href="/open-space">TarugOff  
+    —nuestro Open Space—</a> sino también traer a familia, amigos y compañeros de trabajo
     para pasar un buen rato con todas las actividades que hemos preparado que
     disfrutarán por igual, mayores y pequeños.
 activities:
@@ -182,23 +179,6 @@ faq:
     - question: ¿Hay un límite de aforo?
       answer: S﻿í, 1.000 personas. Si llegamos a ese límite, el próximo año alquilamos
         la Plaza de Toros.
-    - question: Mi sesión no ha salido elegida en la TarugOff, ¿y ahora qué hago?
-      answer: >
-        Pues no pasa nada, disfruta de las sesiones que han salido, o si te
-        encuentras por los pasillos con personas a las 
-
-        que les interesaba tu propuesta, id a tomar un café y hablad sobre ello. Recuerda que la única regla es la regla de 
-
-        los 2 pies ;-)
-    - question: ¿De qué temas se pueden hablar en la TarugoOff?
-      answer: >
-        En honor al espíritu abierto de un Open Space, se puede proponer
-        cualquier tema. Pero en un evento basado en 
-
-        desarrollo de producto, es posible que no haya gente experta en el cultivo de la vid, por lo que es más productivo limitarse a la temática propuesta. Desarrollo de producto es una temática bastante amplia que abarca desde aspectos técnicos a logísticos, pasando por marketing, financiación, diseño y un largo etcétera.
-    - question: ¿Puedo proponer más de una sesión en la TarugOff?
-      answer: |
-        Sí, puedes presentar tantas como quieras.
     - question: ¡Tengo más dudas!
       answer: No pasa nada. Como siempre, escribe a
         [tarugoconf@bonillaware.com](mailto:tarugoconf@bonillaware.com) y allí


### PR DESCRIPTION
Now the open space is separated from the Saturday activities page.

The navigation flow is `home > saturday-tarugo > open-space`.