### PR TITLE
Changed Sngular link at the home page

### DIFF
--- a/_data/home/partners.yml
+++ b/_data/home/partners.yml
@@ -33,7 +33,7 @@ partners:
     text: Ayudamos a las empresas que están transformando el mundo a resolver sus
       problemas tecnológicos y llegar más allá.
   - img: /img/partners/sngular-logo-big.png
-    url: https://www.sngular.com/
+    url: https://www.sngular.com/es/careers-home/?utm_source=Qr+Tarugoconf&utm_medium=Qr&utm_campaign=TarugoConf+2022&utm_id=0001
     alt: SNGULAR
     text: Adaptive Advantage  for a world in constant change.
   - img: /img/partners/web-color-black-transparent.png


### PR DESCRIPTION
Sngular contact asked to change the link to the Careers page

https://www.sngular.com/es/careers-home/?utm_source=Qr+Tarugoconf&utm_medium=Qr&utm_campaign=TarugoConf+2022&utm_id=0001